### PR TITLE
#52 bugfix for server crashing client

### DIFF
--- a/core/src/com/benberi/cadesim/GameContext.java
+++ b/core/src/com/benberi/cadesim/GameContext.java
@@ -132,6 +132,8 @@ public class GameContext {
     public Team myTeam;
     public ChannelPipeline pipeline;
 
+	private boolean clientDisconnected;
+
     public GameContext(BlockadeSimulator main) {
         this.tools = new GameToolsContainer();
 
@@ -353,22 +355,22 @@ public class GameContext {
 
             switch (response) {
                 case LoginResponsePacket.BAD_VERSION:
-                    connectScene.setPopup("Outdated client");
+                    connectScene.setPopup("Outdated client", true);
                     break;
                 case LoginResponsePacket.NAME_IN_USE:
-                    connectScene.setPopup("Display name already in use");
+                    connectScene.setPopup("Display name already in use", true);
                     break;
                 case LoginResponsePacket.BAD_SHIP:
-                    connectScene.setPopup("The selected ship is not allowed");
+                    connectScene.setPopup("The selected ship is not allowed", true);
                     break;
                 case LoginResponsePacket.SERVER_FULL:
-                    connectScene.setPopup("The server is full");
+                    connectScene.setPopup("The server is full", true);
                     break;
                 case LoginResponsePacket.BAD_NAME:
-                	connectScene.setPopup("That ship name is not allowed");
+                	connectScene.setPopup("That ship name is not allowed", true);
                 	break;
                 default:
-                    connectScene.setPopup("Unknown login failure");
+                    connectScene.setPopup("Unknown login failure", true);
                     break;
             }
 
@@ -400,7 +402,7 @@ public class GameContext {
 		if ((!getIsConnected()) && getIsInLobby()) {
 			System.out.println("Returned to lobby");
 		}else {
-			connectScene.setPopup("You have disconnected from the server.");
+			connectScene.setPopup("You have disconnected from the server.", true);
 		}
 	}
 
@@ -445,13 +447,30 @@ public class GameContext {
     	sendPacket(packet);
     }
 
+    /*
+     * When the client (or user) decides to disconnect
+     */
     public void disconnect() {
+    	setClientInitiatedDisconnect(true); // wedunnit!
         setReady(false);
         setIsConnected(false);
         setIsInLobby(true);
         getServerChannel().disconnect();
 		getConnectScene().setState(ConnectionSceneState.DEFAULT);
-		connectScene.setPopup("Returning to Lobby...");
+		connectScene.setPopup("Returning to Lobby...", false);
+		System.out.println("we disconnectedd.");
+    }
+
+    /*
+     * When the server decides to disconnect
+     */
+    public void handleServersideDisconnect() {
+        setReady(false);
+        setIsConnected(false);
+        setIsInLobby(true);
+		getConnectScene().setState(ConnectionSceneState.DEFAULT);
+		System.out.println("server disconnected");
+		connectScene.setPopup("Server disconnected, returning to Lobby...", false);
     }
 
     public SceneAssetManager getAssetObject() {
@@ -475,4 +494,12 @@ public class GameContext {
     public boolean getIsInLobby() {
         return isInLobby;
     }
+
+	public boolean clientInitiatedDisconnect() {
+		return clientDisconnected;
+	}
+
+	public void setClientInitiatedDisconnect(boolean clientDisconnected) {
+		this.clientDisconnected = clientDisconnected;
+	}
 }

--- a/core/src/com/benberi/cadesim/client/ClientConnectionTask.java
+++ b/core/src/com/benberi/cadesim/client/ClientConnectionTask.java
@@ -69,8 +69,13 @@ public class ClientConnectionTask extends Bootstrap implements Runnable {
 		            	@Override public void operationComplete(ChannelFuture future) throws Exception{
 		            		worker.shutdownGracefully().addListener(e -> {
 		            			context.dispose();
-		            			context.getConnectScene().closePopup();});
-		    		        }
+		            			context.getConnectScene().closePopup();
+		            		});
+		            			if (!context.clientInitiatedDisconnect()) { // whodunnit?
+		            				context.handleServersideDisconnect();
+		            			}
+	            				context.setClientInitiatedDisconnect(false); // clear flag
+		    		    }
 		        	});
 		        	callback.onSuccess(channel);
 		        }

--- a/core/src/com/benberi/cadesim/game/scene/impl/connect/ConnectScene.java
+++ b/core/src/com/benberi/cadesim/game/scene/impl/connect/ConnectScene.java
@@ -100,6 +100,7 @@ public class ConnectScene implements GameScene, InputProcessor {
     private SelectBox<RoomNumberLabel> roomLabel;
 
     private boolean popup;
+    private boolean allowPopupClose;
     private String popupMessage;
     private boolean popupCloseHover;
     private boolean loginHover;
@@ -481,18 +482,23 @@ public class ConnectScene implements GameScene, InputProcessor {
                 renderer.setColor(new Color(213 / 255f, 54 / 255f, 53 / 255f, 1));
                 renderer.rect(x, y, width, height);
 
-                if (popupCloseHover) {
+                if (popupCloseHover && allowPopupClose) {
                     renderer.setColor(new Color(250 / 255f, 93 / 255f, 93 / 255f, 1));
                 } else {
                     renderer.setColor(new Color(170 / 255f, 39 / 255f, 39 / 255f, 1));
                 }
-                renderer.rect(x + 330, y, 70, 50);
+
+                if (allowPopupClose) {
+                    renderer.rect(x + 330, y, 70, 50);
+                }
                 renderer.end();
                 batch.begin();
                 font.setColor(Color.WHITE);
                 font.draw(batch, popupMessage, x + ((400 / 2) - layout.width / 2) - 30, y + (25 + (layout.height / 2)));
 
-                font.draw(batch, "Close", x + 400 - 55, y + (25 + (layout.height / 2)));
+                if (allowPopupClose) {
+                    font.draw(batch, "Close", x + 400 - 55, y + (25 + (layout.height / 2)));
+                }
                 batch.end();
             }
         }
@@ -541,8 +547,9 @@ public class ConnectScene implements GameScene, InputProcessor {
     }
 
 
-    public void setPopup(String message) {
+    public void setPopup(String message, boolean allowPopupClose) {
         popup = true;
+        this.allowPopupClose = allowPopupClose;
         popupMessage = message;
         name.setDisabled(true);
         address.setDisabled(true);
@@ -652,23 +659,17 @@ public class ConnectScene implements GameScene, InputProcessor {
     private void performLogin() throws UnknownHostException {
         loginAttemptTimestampMillis = System.currentTimeMillis();
 
-        if (name.getText().length() > Constants.MAX_NAME_SIZE) {
-            setPopup("Display name must be less than " + Constants.MAX_NAME_SIZE + " letters.");
-        }
-        else if (code.getText().length() > Constants.MAX_CODE_SIZE)
-        {
-        	setPopup("Server code must be less than " + Constants.MAX_CODE_SIZE + " letters.");
-        }
-        else if (name.getText().length() <= 0) {
-            setPopup("Please enter a display name.");
-        }
-        else if (address.getText().length() <= 0) {
-            setPopup("Please enter an IP Address.");
-        }
-        else if (!RandomUtils.validIP(address.getText()) && !RandomUtils.validUrl(address.getText())) {
-            setPopup("Please enter a valid IP Address or URL.");
-        }
-        else {
+		if (name.getText().length() > Constants.MAX_NAME_SIZE) {
+			setPopup("Display name must be less than " + Constants.MAX_NAME_SIZE + " letters.", true);
+		} else if (code.getText().length() > Constants.MAX_CODE_SIZE) {
+			setPopup("Server code must be less than " + Constants.MAX_CODE_SIZE + " letters.", true);
+		} else if (name.getText().length() <= 0) {
+			setPopup("Please enter a display name.", true);
+		} else if (address.getText().length() <= 0) {
+			setPopup("Please enter an IP Address.", true);
+		} else if (!RandomUtils.validIP(address.getText()) && !RandomUtils.validUrl(address.getText())) {
+			setPopup("Please enter a valid IP Address or URL.", true);
+		} else {
             // Save current choices for next time
             try {
                 String[] resolution = ResolutionTypeLabel.restypeToRes(resolutionType.getSelectedIndex());
@@ -738,7 +739,7 @@ public class ConnectScene implements GameScene, InputProcessor {
     }
 
     public void loginFailed() {
-        setPopup("Could not connect to server.");
+        setPopup("Could not connect to server.", true);
     }
 
     public void setState(ConnectionSceneState state) {


### PR DESCRIPTION
Fixes #52, #62
- bugfix for server crashing client - now a loss of connection is handled gracefully.
- Differentiate between server and client initiated disconnects.
- Hide the close button on the connectscene popup when the user should not click it.